### PR TITLE
Update schemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["sandstorm"]
 build = "build.rs"
 
 [dependencies]
-capnp = "0.11"
+capnp = "0.12"
 
 [build-dependencies]
-capnpc = "0.11"
+capnpc = "0.12"

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,20 @@
 extern crate capnpc;
 
 fn main() {
-    ::capnpc::CompilerCommand::new()
+    capnpc::CompilerCommand::new()
         .src_prefix("schema")
+        .file("schema/supervisor.capnp")
         .file("schema/util.capnp")
         .file("schema/powerbox.capnp")
         .file("schema/identity.capnp")
         .file("schema/activity.capnp")
         .file("schema/grain.capnp")
-	    .file("schema/web-session.capnp")
+        .file("schema/web-session.capnp")
         .file("schema/ip.capnp")
         .file("schema/email.capnp")
         .file("schema/web-publishing.capnp")
         .file("schema/sandstorm-http-bridge.capnp")
-        .run().expect("compiling");
+        .file("schema/api-session.capnp")
+        .run()
+        .expect("compiling");
 }

--- a/schema/activity.capnp
+++ b/schema/activity.capnp
@@ -40,8 +40,6 @@ struct ActivityEvent {
   # important for deciding who gets notified and for grouping those notifications: a user might
   # subscribe to a particular thread, and e.g. email notifications related to a thread may be
   # designed to appear as a single email thread.
-  #
-  # TODO(now): Should this be a capability to a `Thread` object which must be created separately?
 
   struct ThreadInfo {
     path @0 :Text;
@@ -76,8 +74,26 @@ struct ActivityEvent {
     identity @0 :Identity.Identity;
 
     mentioned @1 :Bool;
-    # This user is "mentioned" by this event. This is a hint that they should be more actively
-    # notified.
+    # This user is explicitly "mentioned" by this event, e.g. like an @-mention on Twitter or
+    # GitHub. In the activity log, the event may explicitly show who was mentioned, and mentioned
+    # users may be notified even if they are not explicitly subscribed to the event.
+    #
+    # Note that if you want a user to be notified but they *aren't* actually "mentioned" by the
+    # event, you may want to use `subscribed`, below, instead. As a rule of thumb, think about
+    # how to complete this sentence: "You received this notification because _______" If the blank
+    # should say "you were mentioned", then set `mentioned = true`. If it would say "you are
+    # subscribed to this thread" (or something like that), set `subscribed = true`.
+
+    subscribed @3 :Bool;
+    # Set true if the application manages a concept of "subscriptions" internally (rather than
+    # letting Sandstorm do it), and that according to this internal computation, the user is
+    # "subscribed" to this event. The effect of this is that the user will be notified of the
+    # event even though it doesn't specifically "mention" them. The user may be informed that they
+    # are being notified because they are subscribed.
+    #
+    # Generally, an app should *not* use this field if it uses `autoSubscribeToThread`,
+    # `autoSubscribeToGrain`, or the Sandstorm APIs for notification subscriptions. Only use this
+    # field if your app is implementing its own notion of subscriptions.
 
     canView @2 :Bool;
     # This user can view this event *even if* they do not meet the `requiredPermission` in the
@@ -143,7 +159,7 @@ struct ActivityTypeDef {
   # Should subscribers to this event (including subscribers to the event's thread, if any, and
   # subscribers to the event's grain) receive a notification of this event, by default?
   #
-  # Note that when the user explicitly subscribes through they UI, they will have the opportunity
+  # Note that when the user explicitly subscribes through the UI, they will have the opportunity
   # to choose exactly which event types they want to produce notifications. Moreover, when an app
   # provides a "subscribe" button in its own UI, and the user clicks it, the app can specify
   # different defaults that should apply to that button.

--- a/schema/api-session.capnp
+++ b/schema/api-session.capnp
@@ -1,0 +1,136 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xeb014c0c3413cbfb;
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using WebSession = import "web-session.capnp";
+using IpAddress = import "ip.capnp".IpAddress;
+
+interface ApiSession @0xc879e379c625cdc7 extends(WebSession.WebSession) {
+  # A special case of WebSession but for APIs. It doesn't provide much other
+  # than a unique type id that we can identify ApiSessions with
+
+  struct Params {
+    # Normally, we strip the remote address from requests, since most applications shouldn't need
+    # it.  However, for those that benefit from it (like analytics), clients can opt into passing
+    # their IP on to the backend by adding an "X-Sandstorm-Passthrough: address" header to their
+    # request.  This would be a privacy leak for WebSession, since the grain can give the client
+    # scripts which would send the header, but ApiSession requires a user action, so it's safe
+    # here.
+    remoteAddress @0 :IpAddress;
+  }
+
+  struct PowerboxTag {
+    # A tag used for PowerboxDescriptors describing HTTP APIs. Such descriptors should typically
+    # indicate `ApiSession` as the requested interface and use PowerboxTag to specify what API is
+    # expected (so, the tag ID is ApiSession's ID, but the tag value is an ApiSession.PowerboxTag).
+    #
+    # Usually, this tag is used to request APIs implemented by internet services external to
+    # Sandstorm. However, a Sandstorm grain may advertise itself as supporting a compatible API
+    # to the Powerbox, and if so the Powerbox will allow the user to select that grain for such
+    # requests. Note that publishing an `ApiSession` has nothing to do with `UiView` or Sandstorm's
+    # normal HTTP API support.
+    #
+    # Requests of this type trigger the HTTP driver, such that the powerbox UI will display a
+    # special flow for connecting to external web services. The Powerbox will also surface other
+    # grains that advertise their ability to handle these requests under the usual matching rules.
+    # This struct is carefully designed such that the usual Powerbox query rules make sense for
+    # performing such queries.
+    #
+    # If you make a Powerbox request containing multiple PowerboxDescriptors describing HTTP APIs,
+    # the HTTP driver will offer the user a choice among the options. This can make sense for, say,
+    # allowing the user to choose from multiple popular servers implementing the same protocol, or
+    # to choose whether or not to grant the app optional permissions (OAuth scopes). The HTTP
+    # driver will return a capability with a descriptor matching one of the requested descriptors
+    # which best-describes the user's choice.
+
+    canonicalUrl @0 :Text;
+    # The standard URL at which this service is found. Use this especially for traditional SaaS
+    # services. For example, you might request "https://api.github.com" to request access to the
+    # GitHub API.
+    #
+    # If you include a path in the URL, requests will automatically be prefixed with that path. You
+    # should usually include enough path components to identify a specific product and version, but
+    # usually not specific collection types within that product. For example, you would request the
+    # Google Calendar API version 2 as "https://apidata.googleusercontent.com/caldav/v2". However,
+    # you would not normally request "https://api.github.com/users" because "GitHub users" is not
+    # considered a separate API but rather one part of the overall GitHub API. Note that
+    # `canonicalUrl` should never end with a '/', because a '/' is added implicitly to separate
+    # the API URL from the individual request's path.
+    #
+    # The HTTP driver will present `canonicalUrl` as a strong suggestion to the user. However, the
+    # user is always allowed to substitute a different URL instead, causing requests to be
+    # redirected to some other service. This is the user's choice. In cases where the app does not
+    # trust the user, the app will need to defend itself against the possibility that the user
+    # connects it to a malicious server.
+    #
+    # The Powerbox will also offer matches published by other grains using the usual query matching
+    # rules. That is, a grain may advertise that it can handle queries for HTTP APIs with a
+    # particular `canonicalUrl`, indicating that the grain offers ApiSession capabilities
+    # implementing a compatible protocol.
+    #
+    # TODO(soon): How do we request a standard protocol that doesn't have a canonical URL, like
+    #     WebDAV? Does any of ApiSession.PowerboxTag even make sense in this case?
+    # TODO(soon): How do we request a single resource with a particular MIME type? Probably should
+    #     be a separate interface, which http-bridge can implement...
+
+    struct OAuthScope {
+      name @0 :Text;
+    }
+
+    oauthScopes @1 :List(OAuthScope);
+    # List of OAuth scopes required by the requesting app. OAuth APIs usually publish a list
+    # of "scope" names representing permissions that can be requested. For example, see:
+    #
+    #     https://developer.github.com/v3/oauth/#scopes
+    #
+    # When this list is present (even if empty), it indicates that the requested API requires
+    # OAuth-based authentication. The HTTP driver will guide the user through connecting their
+    # Sandstorm account to the remote service and requesting the appropriate permissions.
+    #
+    # The Sandstorm project maintains an ad hoc mapping of hostnames to OAuth endpoints allowing
+    # the HTTP driver to automatically determine what kind of OAuth request to make for a given
+    # `canonicalUrl`. For example, if `canonicalUrl` is `https://api.github.com`, the HTTP driver
+    # will initiate a Github OAuth handshake. For any URL under apidata.googleusercontent.com, the
+    # driver will initiate a Google OAuth handshake. Etc. Unfortunately, it is not possible to
+    # make OAuth requests to endpoints not on the list. However, we welcome pull requests to add
+    # new endpoints, large or small.
+    #
+    # Sandstorm grains offering compatible APIs may wish to list the OAuth scopes they support.
+    # Powerbox matching rules state that when a Powerbox query and potential matching descriptor
+    # both contain a field of list-of-struct type, then they are treated as sets, and the match
+    # must advertise a superset of the request. Therefore, if you list OAuth scopes when
+    # publishing, then only requests for a subset of these will lead to your offer being listed in
+    # the Powerbox. Often, offers will want to leave `oauthScopes` null, which will cause the scope
+    # list to be ignored for matching purposes (always match).
+
+    authentication @2 :Text;
+    # If not null, indicates that this endpoint is expected to need old-fashion authentication.
+    # The field contains a text string naming the type of authentication. Currently there is only
+    # one type recognized: "basic", meaning HTTP Basic Auth. Specifying this instructs the HTTP
+    # driver to prompt the user for a username and password.
+    #
+    # Note that even if this isn't specified, the HTTP driver will probe the target server to see
+    # if it demands authentication and, if so, will prompt the user for a password anyway. Thus
+    # this is only needed in cases where the target server supports both authenticated and
+    # unauthenticated use and thus the probe will not notice the need for authentication.
+    #
+    # When publishing support of HTTP APIs to the Powerbox, you should usually leave this field
+    # null, so that it is not considered for matching.
+  }
+}

--- a/schema/email.capnp
+++ b/schema/email.capnp
@@ -122,7 +122,7 @@ interface VerifiedEmail @0xf88bf102464dfa5a {
   #
   # To verify a user, make a powerbox request for `VerifiedEmail`. In your `PowerboxDescriptor`,
   # set the tag value to a `VerifiedEmail.PowerboxTag` which has `authority` set to the
-  # capability returned by you `EmailVerifier`'s `getAuthority()` method. The user will be asked to
+  # capability returned by your `EmailVerifier`'s `getAuthority()` method. The user will be asked to
   # choose one of their addresses. The Powerbox returns an `VerifiedEmail` for the address they
   # chose. You must then pass this object to `EmailVerifier.verifyEmail()` to verify that
   # the capability really is attached to the user's account and obtain the final address.
@@ -152,7 +152,7 @@ interface VerifiedEmail @0xf88bf102464dfa5a {
     # the matching address.
 
     domain @2 :Text;
-    # Specify a domain (like "example.com") in a Powerbox request to requiure that the user choose
+    # Specify a domain (like "example.com") in a Powerbox request to require that the user choose
     # an address under the specified domain. The user will still have the choice to refuse
     # verification, but will not be offered addresses under other domains.
     #

--- a/schema/grain.capnp
+++ b/schema/grain.capnp
@@ -119,6 +119,107 @@ interface SandstormApi(AppObjectId) {
   backgroundActivity @9 (event :Activity.ActivityEvent);
   # Post an activity event to the grain's activity log that was *not* initiated by any particular
   # user. For activity that should be attributed to a user, use SessionContext.activity().
+
+  getIdentityId @10 (identity: Identity.Identity) -> (id :Data);
+  # Gets the ID of the identity, as it would appear in UserInfo.identityId.
+  #
+  # This method is here on `SandstormApi` rather than on `Identity` in order to ease a possible
+  # future transition to a model where identity IDs are not globally stable and each grain has a
+  # separate (possibly incompatible) map from identity ID to account ID.
+
+  schedule @11 ScheduledJob;
+  # Schedule a callback to be executed in the future.
+  #
+  # The job may be scheduled to execute once at a specific time, or periodically. See
+  # `ScheduledJob` for more information.
+  #
+  # When this method returns, the job will have been scheduled.
+}
+
+struct ScheduledJob {
+  # A job to be scheduled by `SandstormApi.schedule()`.
+
+  name @0 :Util.LocalizedText;
+  # A name for the job. This will be used to describe the job to the user.
+
+  callback @1 :Callback;
+  # A callback to actually execute when it is time to run the job.
+  #
+  # In addition to implementing the `Callback` interface below, this must also
+  # implement `AppPersistent`. When a request to schedule the job is made, Sandstorm
+  # will `save()` the callback, and then later `restore()` it when it is time to
+  # run the job. See `AppPersistent` for more details on how this works.
+  #
+  # Note that, in some circumstances, the app may need to save some information
+  # locally to recognize the task. There is a possibility that between scheduling
+  # the job and actually saving the information, The app may be killed, the server
+  # may crash, or some other failure may occur that prevents the app from saving
+  # the information. We recommend dealing with this in one of the following ways:
+  #
+  # - Where possible, save all needed information in the `objectId` returned
+  #   by `AppPersistent.save()`; this avoids the race condition entirely.
+  # - Otherwise, in your implementation of `MainView.restore()`, if you are asked
+  #   to restore a callback you don't recognize, return a dummy callback that does
+  #   nothing, and returns `cancelFutureRuns = true`. This will cause Sandstorm to
+  #   cancel and delete the unknown job.
+  #
+  # When the callback is called, Sandstorm will avoid killing the grain until the callback returns.
+  # If the callback throws a "disconnected" exception, or if Sandstorm is forced to kill the
+  # grain for some reason, the callback will be retried. After a limited number of failed retries,
+  # Sandstorm may alert the owner to a problem and stop retrying.
+
+  interface Callback {
+    run @0 () -> (cancelFutureRuns :Bool = false);
+    # Run the job. If the return value has `cancelFutureRuns = true` and this is a periodic job,
+    # the job will be cancelled and will not be run again.
+  }
+
+  schedule :union {
+  # The actual schedule of the job.
+
+    oneShot :group {
+    # Run the job exactly once.
+
+      when @2 :Util.DateInNs;
+      # The time at which the job should be run.
+
+      slack @3 :Util.DurationInNs;
+      # In order to improve resource utilization, Sandstorm prefers imprecise
+      # scheduling -- this allows it to choose a time of low activity to invoke
+      # the callback. The `slack` field tells Sandstorm how much freedom it
+      # has -- it may schedule the task any time between `when` and `when +
+      # slack`. A value of zero for `slack` is special: it is equivalent to
+      # 1/8th of the difference between now and `when` -- this sets the window
+      # adaptively, such that the further in the future the event is scheduled,
+      # the more slack it has. You must explicitly set a non-zero value if you
+      # need better precision. Additionally, the value must be greater than
+      # `minimumSchedulingSlack`, or an exception will be thrown. If you need
+      # better precision than this, you should schedule a callback for slightly
+      # before the target time, then countdown the remaining time in-process.
+    }
+
+    periodic @4 :SchedulingPeriod;
+    # Run the job on a regular interval.
+    #
+    # In order to improve resource utilization, Sandstorm prefers imprecise
+    # scheduling -- this allows it to choose a time of low activity to
+    # invoke the callback. Therefore, Sandstorm guarantees that the callback
+    # will be called once per scheduling period, but does not make any guarantees
+    # about exactly when in that period the call will occur. If you need more
+    # precise scheduling, you will need to use `oneShot`, and schedule the next
+    # occurance from the callback itself, before returning.
+  }
+}
+
+const minimumSchedulingSlack :Util.DurationInNs = 300000000000;
+# 5 minutes: The minimum value allowable for the `slack` parameter passed to `scheduleAt()`.
+
+enum SchedulingPeriod {
+  annually @3;
+  monthly @2;
+  weekly @4;
+  daily @1;
+  hourly @0;
 }
 
 interface UiView @0xdbb4d798ea67e2e7 {
@@ -136,6 +237,13 @@ interface UiView @0xdbb4d798ea67e2e7 {
   # sheet.  To accomplish this, the app would create an alternate UiView object that implements
   # an interface just to those cells, and then would use `UiSession.offer()` to offer this object
   # to the user.  The user could then choose to open it, share it, save it for later, etc.
+  #
+  # TODO(apibump): Parameterize UiView on:
+  # - A struct type representing permissions, which must have only boolean fields, each annotated
+  #   with a PermissionDef. Replace all istances of PermissionSet with this.
+  # - An enum type representing roles, each annotated with its permission set and a RoleDef.
+  #   (Requires Cap'n Proto changes to allow parametirizing on enum types, I guess...)
+  # - An enum type representing activity event types, each annotated with an ActivityTypeDef.
 
   getViewInfo @0 () -> ViewInfo;
   # Get metadata about the view, especially relating to sharing.
@@ -412,7 +520,9 @@ interface SessionContext {
   # callback to the grain will occur. You can listen for such a message like so:
   # window.addEventListener("message", function (event) {
   #   if (event.data.rpcId === myRpcId && !event.data.error) {
-  #     // pass event.data.token to your app's server and call SessionContext.claimRequest() with it
+  #     // Pass `event.data.token` to your app's server and call SessionContext.claimRequest() with
+  #     // it. The token is guaranteed to be a URL-safe string. That is, passing it through
+  #     // encodeURIComponent() should be a no-op.
   #   }
   # }, false)
 
@@ -596,15 +706,50 @@ interface ViewSharingLink extends(SharingLink) {
 # Backup and Restore
 
 struct GrainInfo {
+  # Format of metadata file stored in grain backups.
+
   appId @0 :Text;
   appVersion @1 :UInt32;
   title @2 :Text;
+
+  ownerIdentityId @3 :Text;
+
+  users @4 :List(User);
+  # Record of users with who had accessed this grain. This can be used to ensure that if a restored
+  # grain is shared with the same users, they receive the same identities, rather than appearing
+  # to be new people.
+
+  struct User {
+    identityId @0 :Text;
+    # Identity ID of this user within the app.
+
+    credentialIds @1 :List(Text);
+    # The user's login credential IDs. If a user with a matching credential visits the restored
+    # grain, they will regain the same identity. Credential IDs are consistent across differnt
+    # Sandstorm servers (as long as the same authentication mechanisms are used), so this can allow
+    # identities to be restored even on a new server.
+    #
+    # Non-login credentials are not included because those credentials could be shared by multiple
+    # users. However, non-login credentials could be used for matching when restoring identities
+    # later.
+
+    profile @2 :Identity.Profile;
+    # User's profile. Could be useful to allow the human owner of the restored grain to manually
+    # remap identities.
+  }
+
+  originalGrainId @5 :Text;
+  # The grain's original ID. With admin approval, grains could be allowed to receive the same IDs
+  # when restored on a new server.
+
+  # TODO(someday): Record the whole sharing / capability graph? This gets complicated since grains
+  #   may have been shared via other grains, etc.
 }
 
 # ========================================================================================
 # Persistent objects
 
-interface AppPersistent(AppObjectId) {
+interface AppPersistent @0xaffa789add8747b8 (AppObjectId) {
   # To make an object implemented by your own app persistent, implement this interface.
   #
   # `AppObjectId` is a structure like a URL which identifies a specific object within your app.
@@ -639,6 +784,10 @@ interface AppPersistent(AppObjectId) {
   # canonicalization rules) so that it can recognize when the same object is saved multiple times.
   # `MainView.drop()` will be called when all such references have been dropped by their respective
   # clients.
+  #
+  # TODO(cleanup): How does `label` here relate to `PowerboxDisplayInfo` on `offer()` and
+  #   `fulfillRequest()`? Maybe `label` here should actually be `PowerboxDisplayInfo` and those
+  #   other methods shouldn't take that parameter?
 }
 
 interface MainView(AppObjectId) extends(UiView) {

--- a/schema/identity.capnp
+++ b/schema/identity.capnp
@@ -23,7 +23,7 @@ using Util = import "util.capnp";
 using PermissionSet = List(Bool);
 # Set of permission IDs, represented as a bitfield.
 
-interface Identity {
+interface Identity @0xc084987aa951dd18  {
   # Represents a user identity.
   #
   # Things you can do:
@@ -38,6 +38,17 @@ interface Identity {
   # This capability is always persistable.
 
   # TODO(someday): Public key info? Ability to seal messages / check signatures?
+
+  struct PowerboxTag {
+    # Tag to be used in a `PowerboxDescriptor` to describe an `Identity`.
+
+    permissions @0 :PermissionSet;
+    # In a query, the permissions that the requester wishes to be held by the identity. When
+    # the powerbox UI asks the user to select a role, it hides any roles that do not provide all of
+    # these permissions.
+    #
+    # In a fulfillment, the current permissions actually held by the identity.
+  }
 
   getProfile @0 () -> (profile: Profile);
   # Get the identity's current profile.

--- a/schema/sandstorm-http-bridge.capnp
+++ b/schema/sandstorm-http-bridge.capnp
@@ -21,6 +21,7 @@
 $import "/capnp/c++.capnp".namespace("sandstorm");
 using Grain = import "grain.capnp";
 using Identity = import "identity.capnp";
+using Powerbox = import "powerbox.capnp";
 
 interface SandstormHttpBridge {
   # Bootstrap interface provided to the app on a Unix domain socket at /tmp/sandstorm-api.
@@ -32,8 +33,46 @@ interface SandstormHttpBridge {
   # Get the SessionContext corresponding to a UiSession. The appropriate `id` value can be read
   # from the X-Sandstorm-Session-Id header inserted by sandstorm-http-bridge.
 
+  getSessionRequest @4 (id :Text) -> (requestInfo :List(Powerbox.PowerboxDescriptor));
+  # Get the requestInfo for a powerbox request session. The `id` parameter is the same as for
+  # `getSessionContext`. This is only valid if the current session actually is a request
+  # session. If it is, the `X-Sandstorm-Session-Type` header will be set to 'request'.
+
+  getSessionOffer @5 (id :Text) -> (offer :Capability, descriptor :Powerbox.PowerboxDescriptor);
+  # Get the offer information for a powerbox offer session. The `id` parameter is the same as
+  # for `getSessionContext`. This is only valid if the current session actually is an offer
+  # session. If it is, the `X-Sandstorm-Session-Type` header will be set to 'offer'.
+
   getSavedIdentity @2 (identityId :Text) -> (identity :Identity.Identity);
   # If BridgeConfig.saveIdentityCaps is true for this app, then you can call this method to fetch
   # the saved identity capability for a particular identityId as passed in the
   # `X-Sandstorm-User-Id` header.
+
+  saveIdentity @3 (identity :Identity.Identity);
+  # If BridgeConfig.saveIdentityCaps is true for this app, adds the given identity to the
+  # grain's database, allowing it to be fetched later with `getSavedIdentity()`.
+}
+
+interface AppHooks (AppObjectId) {
+  # When connecting to the bridge's domain socket at /tmp/sandstorm-api, the
+  # application may supply this as a bootstrap interface. If the app chooses
+  # to do so, it should also set `bridgeConfig.expectAppHooks = true` in the
+  # package's PackageDefinition.
+  #
+  # The `AppObjectId` type parameter should be the same as that for any
+  # objects exported by the app that implement Grain.AppPersistent.
+
+  getViewInfo @0 () -> Grain.UiView.ViewInfo;
+  # Like Grain.UiView.getViewInfo. If AppHooks is supplied, the bridge will
+  # delegate UiView.getViewInfo to this method. If it raises unimplemented,
+  # the bridge will fall back to reading the viewInfo from the bridgeConfig.
+
+  restore @1 (objectId :AppObjectId) -> (cap :Capability);
+  # Like Grain.MainView.restore. The bridge will use this to delegate restoring
+  # any objects provided by the app, rather than the bridge itself. Such objects
+  # must implement `Grain.AppPersistent.save` per the comments there and in
+  # Grain.MainView.
+
+  drop @2 (objectId :AppObjectId);
+  # Like Grain.MainView.drop. See the comments for restore.
 }

--- a/schema/supervisor.capnp
+++ b/schema/supervisor.capnp
@@ -1,0 +1,397 @@
+# Sandstorm - Personal Cloud Sandbox
+# Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@0xc7205d6d32c7b040;
+# This file contains interfaces defining communication between a Sandstorm grain supervisor and
+# other components of the system. These interfaces are NOT used by Sandstorm applications.
+
+$import "/capnp/c++.capnp".namespace("sandstorm");
+
+using Util = import "util.capnp";
+using Grain = import "grain.capnp";
+using Persistent = import "/capnp/persistent.capnp".Persistent;
+using Activity = import "activity.capnp";
+using Identity = import "identity.capnp";
+
+interface Supervisor {
+  # Default capability exported by the supervisor process.
+
+  getMainView @0 () -> (view :Grain.UiView);
+  # Get the grain's main UiView.
+
+  keepAlive @1 (core :SandstormCore);
+  # Must call periodically to prevent supervisor from killing itself off.  Call at least once
+  # per minute.
+  #
+  # `core` may be null. If not null, then it is a new copy of the SandstormCore capability which
+  # should replace the old one. This allows the grain to recover if the original SandstormCore
+  # becomes disconnected.
+  #
+  # TODO(reliability): Passing `core` here is an ugly hack. The supervisor really needs a way to
+  #   proactively reconnect.
+
+  syncStorage @8 ();
+  # Calls syncfs() on /var.
+
+  shutdown @2 ();
+  # Shut down the grain immediately.  Useful e.g. when upgrading to a newer app version.  This
+  # call will never return successfully because the process kills itself.
+
+  obsoleteGetGrainSize @3 () -> (size :UInt64);
+  obsoleteGetGrainSizeWhenDifferent @4 (oldSize :UInt64) -> (size :UInt64);
+  # OBSOLETE: We used to pull the grain size from the supervisor. Now the supervisor pushes the
+  #   size through SandstormCore.
+
+  restore @5 (ref :SupervisorObjectId, obsolete :List(MembraneRequirement), parentToken :Data)
+          -> (cap :Capability);
+  # Wraps `MainView.restore()`. Can also restore capabilities hosted by the supervisor.
+  #
+  # `obsolete` will always be an empty list. (Sandstorm will call `addRequirements()` immediately
+  # after restore() if needed. Passing the list to restore() was removed because the supervisor
+  # has no way of observing whether the requirements are still valid. `addRequirements()` provides
+  # a mechanism for this.)
+  #
+  # `parentToken` is the API token restored to get this capability. The receiver will want to keep
+  # this in memory in order to pass to `SandstormCore.makeChildToken()` later, if the live
+  # capability is saved again.
+
+  drop @6 (ref :SupervisorObjectId);
+  # Wraps `MainView.drop()`. Can also drop capabilities hosted by the supervisor.
+
+  watchLog @7 (backlogAmount :UInt64, stream :Util.ByteStream) -> (handle :Util.Handle);
+  # Write the last `backlogAmount` bytes of the grain's debug log to `stream`, and then watch the
+  # log for changes, writing them to `stream` as they happen, until `handle` is dropped.
+
+  enum WwwFileStatus {
+    file @0;
+    directory @1;
+    notFound @2;
+  }
+
+  getWwwFileHack @9 (path :Text, stream :Util.ByteStream) -> (status :WwwFileStatus);
+  # Reads a file from under the grain's "/var/www" directory. If the path refers to a regular
+  # file, the contents are written to `stream`, and `status` is returned as `file`. If the path
+  # refers to a directory or is not found, then `stream` is NOT called at all and the method
+  # returns the corresponding status.
+  #
+  # Note that if a Supervisor capability is obtained and used only for `getWwwFileHack()` -- i.e.
+  # `getMainView()` and `restore()` are not called -- then the supervisor will not actually start
+  # the application.
+  #
+  # This method is a temporary hack designed so that Sandstorm's front-end can implement web
+  # publishing -- as defined by HackSessionContext -- without digging directly into the grain's
+  # storage on-disk. Eventually, this mechanism for web publishing will be eliminated entirely
+  # and replaced with a driver and powerbox interactions.
+}
+
+interface SandstormCore {
+  # When the front-end connects to a Sandstorm supervisor, the front-end exports a SandstormCore
+  # capability as the default capability on the connection. This SandstormCore instance is specific
+  # to the supervisor's grain; e.g. the grain ID is used to enforce ownership restrictions in
+  # `restore()` and to fill out the `grainId` field in the `ApiTokens` table in calls to
+  # `wrapSaved()`.
+  #
+  # If the front-end disconnects, this probably means that it is restarting. It will connect again
+  # after restart. In the meantime, the supervisor should queue any RPCs to this interface and
+  # retry them after the front-end has reconnected.
+
+  restore @0 (token :Data) -> (cap :Capability);
+  # Restores an API token to a live capability. Fails if this grain is not the token's owner
+  # (including if the ref has no owner).
+
+  claimRequest @6 (requestToken :Text, requiredPermissions :Identity.PermissionSet)
+               -> (cap :Capability);
+  # Restores a client powerbox request token to a live capability, which can then be saved to get
+  # a proper sturdyref.
+  #
+  # `requiredPermissions` has the same meaning as in SandstormApi.claimRequest(). Note that the
+  # callee will not only check these requirements, but will automatically ensure that the returned
+  # capability has an appropriate `MembraneRequirement` applied; the caller need not concern
+  # itself with this.
+
+  drop @3 (token :Data);
+  # Deletes the corresponding API token. See `MainView.drop()` for discussion of dropping.
+
+  makeToken @1 (ref :SupervisorObjectId, owner :ApiTokenOwner,
+                requirements :List(MembraneRequirement)) -> (token :Data);
+  # When the supervisor receives a save() request for a capability hosted by the app, it first
+  # calls save() on the underlying capability to get an AppObjectId, then calls makeToken() to
+  # convert this to a token which it can then return.
+  #
+  # Similarly, when the supervisor receives a save() request for a capability it itself hosts
+  # (outside of the app), it constructs the appropriate `SupervisorObjectId` and passes it to
+  # `makeToken()`.
+  #
+  # If any of the conditions listed in `requirements` become untrue, the returned token will be
+  # disabled (cannot be restored).
+
+  makeChildToken @5 (parent :Data, owner :ApiTokenOwner,
+                     requirements :List(MembraneRequirement)) -> (token :Data);
+  # Given a token (probably originally passed to `Supervisor.restore()`), create a new token
+  # pointing to the same capability, where if the original token is revoked, the new token is
+  # also transitively revoked.
+
+  getOwnerNotificationTarget @2 () -> (owner :Activity.NotificationTarget);
+  # Get the notification target to use for notifications relating to the grain itself, e.g.
+  # presence of wake locks.
+
+  obsoleteCheckRequirements @4 ();
+  # OBSOLETE: This was never implemented, and wouldn't have worked correctly as specified.
+  #   (It involved an RPC that hangs until something happens, which implicitly requires the ability
+  #   for the server to receive call cancellations, which doesn't exist in node-capnp.)
+
+  backgroundActivity @7 (event :Activity.ActivityEvent);
+  # Implements SandstormApi.backgroundActivity().
+
+  reportGrainSize @8 (bytes :UInt64);
+  # Reports the current disk storage usage of the grain. The supervisor monitors storage usage
+  # while the grain runs and calls this method periodically. In order to avoid unnecessary traffic,
+  # the supervisor may choose not to report insignificant changes.
+
+  getIdentityId @9 (identity :Identity.Identity) -> (id :Data);
+  # Gets the ID of the identity, as it would appear in UserInfo.identityId.
+
+  schedule @10 Grain.ScheduledJob;
+  # Same meaning as `Grain.SandstormApi.schedule()`.
+}
+
+struct MembraneRequirement {
+  # Indicates some condition which, if it becomes untrue, will cause a membrane to be revoked.
+
+  union {
+    tokenValid @0 :Text;
+    # This token is valid only as long as some *other* token is also still valid. `tokenValid`
+    # specifies the `_id` of the other ApiToken.
+
+    permissionsHeld :group {
+      # This token is valid only as long as some vertex in the sharing graph holds some specified
+      # set of permissions on some specified grain.
+
+      union {
+        accountId @5 :Text;
+        # The permissions must be held by the user account with this ID.
+
+        tokenId @6: Text;
+        # The permissions must be held by anyone who bears the token with this ID.
+      }
+
+      grainId @2 :Text;
+      # The grain on which the permissions must be held.
+
+      permissions @3 :Identity.PermissionSet;
+      # The permissions that must be held.
+
+      userId @1 :Text;
+      # Deprecated. See `identityId`.
+    }
+
+    userIsAdmin @4 :Text;
+    # The capability is valid only as long as the given user is an administrator.
+  }
+}
+
+interface SystemPersistent extends(Persistent(Data, ApiTokenOwner)) {
+  # The specialization of `Persistent` used in the "Sandstorm internal" realm, which is the realm
+  # used by Sandstorm system components talking to each other. This realm is NOT seen by Sandstorm
+  # applications; each grain is its own realm, and the Supervisor performs translations
+  # transparently.
+  #
+  # In the Sandstorm internal realm, the type of SturdyRefs themselves is simply `Data`, where the
+  # data is an API token. The SHA-256 hash of this token is an ID into the `ApiTokens` collection.
+  # The token itself is arbitrary random bytes, not ASCII text (this differs from API tokens
+  # created for the purpose of HTTP APIs).
+
+  interface RevocationObserver {
+    dropWhenRevoked @0 (handle :Util.Handle);
+    # Holds on to `handle` until revocation occurs, then drops it.
+  }
+
+  addRequirements @0 (requirements :List(MembraneRequirement), observer :RevocationObserver)
+                  -> (cap :SystemPersistent);
+  # Returns a new version of this same capability with the given requirements added to the
+  # conditions under which the capability may be revoked. Usually, the caller then calls `save()`
+  # on the new capability.
+  #
+  # `observer` is an object that watches for the requirements to become invalid. When that happens,
+  # it drops any handles registered with it. `observer` itself should be held by `cap`, such that
+  # dropping `cap` causes `observer` to be dropped transitively (this allows the observer to stop
+  # observing when no longer needed).
+  #
+  # This call is actually supported on *all* capabilities that are proxied through the supervisor,
+  # not just persistent ones.
+  #
+  # TODO(someday): This method should be supported by all capabilities within the Sansdtorm realm,
+  #   by having every endpoint implement the appropriate membrane. SystemPersistent should probably
+  #   be renamed and split from `Persistent` -- the inheritance heirarchy can be adjusted without
+  #   breaking compatibility.
+}
+
+interface PersistentHandle extends(SystemPersistent, Util.Handle) {}
+
+interface PersistentOngoingNotification extends(SystemPersistent, Activity.OngoingNotification) {}
+
+struct DenormalizedGrainMetadata {
+  # The metadata that we need to present contextual information for shared grains (in particular,
+  # information about the app providing that grain, like icon and title).
+
+  appTitle @0 :Util.LocalizedText;
+  # A copy of the app name for the corresponding UIView for presentation in the grain list.
+
+  union {
+    icon :group {
+      format @1 :Text;
+      # Icon asset format, if present.  One of "png" or "svg"
+
+      assetId @2 :Text;
+      # The asset ID associated with the grain-size icon for this token
+
+      assetId2xDpi @3 :Text;
+      # If present, the asset ID for the equivalent asset as assetId at twice-resolution
+    }
+    appId @4 :Text;
+    # App ID, needed to generate a favicon if no icon is provided.
+  }
+}
+
+struct ApiTokenOwner {
+  # Defines who is permitted to use a particular API token.
+
+  union {
+    webkey @0 :Void;
+    # This API token is for use on "the web", with no specific owner. This is the kind of token
+    # that you get when you use the Sandstorm UI to create a webkey.
+    #
+    # Note that a webkey CANNOT be directly restored by an app, since this would break confinement
+    # (an app could be shipped with a webkey baked in). Instead, the app must make a powerbox
+    # request, and the user may paste in a webkey there. Apps can only restore tokens explicitly
+    # owned by them.
+    #
+    # (HackSessionContext actually allows webkeys to be exchanged for live capabilities, but this
+    # is temporary until the powerbox is built.)
+
+    grain :group {
+      # Owned by a local grain.
+
+      grainId @1 :Text;
+      # Grain ID owning the ref.
+
+      saveLabel @2 :Util.LocalizedText;
+      # As passed to `save()` in Sandstorm's Persistent interface.
+
+      introducerIdentity @9 :Text;
+      # Obsolete. See `clientPowerboxRequest.introducerIdentity`.
+
+      introducerUser @5 :Text;
+      # Obsolete. See `clientPowerboxRequest.introducerIdentity`.
+    }
+
+    clientPowerboxRequest :group {
+      # Owned by a local grain, but only halfway through a client-side powerbox request flow.
+      # The token will be automatically deleted after a short amount of time. Before then, the
+      # grain must call `SandstormApi.claimRequest()` to get a proper sturdyref.
+
+      sessionId @15 :Text;
+      # The ID of the session that created this token.
+
+      grainId @13 :Text;
+      # Obsolete. (The owning grain is the one associated with sessionId.)
+
+      introducerIdentity @14 :Text;
+      # Obsolete. (The introducer identity can be derived from sessionId instead.)
+    }
+
+    clientPowerboxOffer :group {
+       # When a grain calls `SessionContext.offer(cap)` and the powerbox decides to present the
+       # capability as a webkey, we push the offered capability to the client through the
+       # `Sessions` collection as a token with `clientPowerboxOffer` owner. The token will be
+       # automatically deleted after a short amount of time, before which the client must call the
+       # "acceptPowerboxOffer" Meteor method to convert the token into a durable webkey.
+       #
+       # This variant exists to avoid the need to write a durable webkey into the database, where,
+       # due to journaling, it would remain readable forever. In principle, the extra step entailed
+       # by `clientPowerboxOffer` is not strictly necessary, and we should be able to directly
+       # return the webkey without writing anything to the database. That approach, however, is a
+       # bit tricky in the case where Sandstorm is running multiple frontends.
+
+       sessionId @17 :Text;
+       # The ID of the session that is allowed to accept this offer.
+    }
+
+    internet @3 :AnyPointer;
+    # An owner on the public internet, who used the Cap'n Proto public internet transport to call
+    # `save()` and expects it to authenticate them on later `restore()`.
+    #
+    # TODO(someday): Change `AnyPointer` to the type for public internet owners, once the public
+    #   internet Cap'n Proto protocol is defined. (Or, do we want Sandstorm nodes to be able to
+    #   nested within broader networks that aren't the internet? Hmm.)
+
+    frontend @4 :Void;
+    # Owned by the front-end, i.e. stored in its Mongo database.
+
+    user :group {
+      # Owned by a user's identity. If the token represents a UiView, then it will show up in this
+      # user's grain list.
+
+      accountId @18 :Text;
+      # The account that is allowed to restore this token.
+
+      identityId @10 :Text;
+      # The identity ID used to identify this user to the app, in the context of this grain. The
+      # app does not receive the user's account ID because this could allow unwanted correlation
+      # of users between grains, and becaues grains may transfer between Sandstorm instances where
+      # account IDs may differ.
+
+      title @7 :Text;
+      # Title as chosen by the user, or as copied from the sharer.
+
+      # Fields below this line are not actually allowed to be passed to save(), but are added
+      # internally.
+
+      denormalizedGrainMetadata @8 :DenormalizedGrainMetadata;
+      # Information needed to show the user an app title and icon in the grain list.
+
+      userId @6 :Text;
+      # Deprecated. See `identityId`.
+
+      upstreamTitle @11 :Text;
+      # Title as chosen by the grain owner. This field is directly updated whenever the grain owner
+      # changes the title. As an optimization, this field is omitted if the value would be
+      # identical to `title`.
+
+      renamed @12 :Bool;
+      # True if the user has explicitly renamed the grain to differ from the owner's title.
+      # Otherwise, `title` is a copy of either the current or previous value of `upstreamTitle`.
+
+      seenAllActivity @16 :Bool;
+      # True if the user has viewed the grain since the last activity event occurred.
+    }
+  }
+}
+
+struct SupervisorObjectId(AppObjectId) {
+  # Refers to some persistent object which the Supervisor for a particular grain knows how to
+  # restore.
+
+  union {
+    appRef @0 :AppObjectId;
+    # A reference restorable by the app.
+
+    wakeLockNotification @1 :UInt32;
+    # This refers to an OngoingNotification for a wake lock. Note that although the app itself
+    # implements an `OngoingNotification`, the supervisor wraps it in order to detect the `cancel`
+    # call.
+  }
+}

--- a/schema/util.capnp
+++ b/schema/util.capnp
@@ -64,6 +64,15 @@ interface Handle {
   # persistent handles must be designed to account for this, probably by giving the owning user
   # a way to inspect incoming references and remove them manually. Sandstorm automatically provides
   # such an interface for all apps it hosts.
+
+  ping @0 ();
+  # Checks if the handle is still connected. Call this and check for a DISCONNECTED exception to
+  # see if the handle has been disconnected. Servers usually do not implement this method, so any
+  # other exception type should be considered to indicate that the handle is still live.
+  #
+  # This is particularly important when holding a handle to a Sandstorm grain where the handle
+  # represents some sort of long-running operation. The grain will shut down if it doesn't receive
+  # incoming calls at least every 60 seconds, so you may want to ping() it to keep it alive.
 }
 
 interface ByteStream {


### PR DESCRIPTION
This pull request updates the Sandstorm schema files, and adds the schemas for the API session and the Supervisor. The only one that is not updated is the `ip.capnp`. The new version failed to compile; I think the problem is due to a problem loading SystemPersistent in the `capnpc` crate.