### PR TITLE
Actually export ApiSession module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,12 @@ pub mod identity_capnp {
     include!(concat!(env!("OUT_DIR"), "/identity_capnp.rs"));
 }
 
+pub mod api_session_capnp {
+    include!(concat!(env!("OUT_DIR"), "/api_session_capnp.rs"));
+}
+
 pub mod activity_capnp {
-    include!(concat!(env!("OUT_DIR"), "/activity_capnp.rs"));
+  include!(concat!(env!("OUT_DIR"), "/activity_capnp.rs"));
 }
 
 pub mod grain_capnp {


### PR DESCRIPTION
On my last pull request, I didn't actually reexport the ApiSession module. This patch fixes that.